### PR TITLE
Add 'all' option to --stat in compute_coherence() function

### DIFF
--- a/dicelib/connectivity.pyx
+++ b/dicelib/connectivity.pyx
@@ -518,7 +518,7 @@ def compute_connectome_blur(input_tractogram: str, output_connectome: str, weigh
     tmp = np.arange(0,core_extent+gauss_extent+1e-6,spacing)
     tmp = np.concatenate( (tmp,-tmp[1:][::-1]) )
     x, y = np.meshgrid( tmp, tmp )
-    r = sqrt( x*x + y*y )
+    r = np.sqrt( x*x + y*y )
     idx = (r <= core_extent+gauss_extent)
     blurRho = r[idx]
     blurAngle = np.arctan2(y,x)[idx]
@@ -528,7 +528,7 @@ def compute_connectome_blur(input_tractogram: str, output_connectome: str, weigh
     if gauss_extent == 0 :
         blurWeights[:] = 1.0
     else:
-        blur_sigma = gauss_extent / sqrt( -2.0 * np.log( blur_gauss_min ) )
+        blur_sigma = gauss_extent / np.sqrt( -2.0 * np.log( blur_gauss_min ) )
         for i_r in xrange(nReplicas):
             if blurRho[i_r] <= core_extent :
                 blurWeights[i_r] = 1.0

--- a/dicelib/connectivity.pyx
+++ b/dicelib/connectivity.pyx
@@ -1,19 +1,12 @@
-# cython: language_level=3, c_string_type=str, c_string_encoding=ascii, boundscheck=False, wraparound=False, profile=False
+# cython: language_level=3, c_string_type=str, c_string_encoding=ascii, boundscheck=False, wraparound=False, profile=False, nonecheck=False, cdivision=True, initializedcheck=False, binding=False
 from concurrent.futures import ThreadPoolExecutor
-
 from libc.math cimport round as cround, sqrt
 from libcpp cimport bool
-
 import nibabel as nib
-
 import numpy as np
-
 import os
-
 from scipy.linalg import inv
-
 from time import time
-
 from dicelib.streamline import create_replicas
 from dicelib.ui import ProgressBar, set_verbose, setup_logger
 from dicelib.utils import check_params, File, Num, format_time
@@ -525,7 +518,7 @@ def compute_connectome_blur(input_tractogram: str, output_connectome: str, weigh
     tmp = np.arange(0,core_extent+gauss_extent+1e-6,spacing)
     tmp = np.concatenate( (tmp,-tmp[1:][::-1]) )
     x, y = np.meshgrid( tmp, tmp )
-    r = np.sqrt( x*x + y*y )
+    r = sqrt( x*x + y*y )
     idx = (r <= core_extent+gauss_extent)
     blurRho = r[idx]
     blurAngle = np.arctan2(y,x)[idx]
@@ -535,7 +528,7 @@ def compute_connectome_blur(input_tractogram: str, output_connectome: str, weigh
     if gauss_extent == 0 :
         blurWeights[:] = 1.0
     else:
-        blur_sigma = gauss_extent / np.sqrt( -2.0 * np.log( blur_gauss_min ) )
+        blur_sigma = gauss_extent / sqrt( -2.0 * np.log( blur_gauss_min ) )
         for i_r in xrange(nReplicas):
             if blurRho[i_r] <= core_extent :
                 blurWeights[i_r] = 1.0

--- a/dicelib/scripts/dice_tractogram.py
+++ b/dicelib/scripts/dice_tractogram.py
@@ -443,7 +443,7 @@ def coherence():
         [['tractogram'], {'help': desc['tractogram_filename']}],
         [['sph_func'], {'help': desc['sph_func_filename']}],
         [['out_weights'], {'help': desc['out_weights_filename']}],
-        [['--stat'], {'choices': ['min','mean','max'], 'default': 'min', 'help': desc['stat']}],
+        [['--stat'], {'choices': ['min','mean','max', 'all'], 'default': 'min', 'help': desc['stat']}],
         [['--normalize', '-n'], {'action': 'store_true', 'help': desc['normalize']}],
         [['--trim', '-t'], {'type': float, 'default': 0.05, 'help': desc['trim']}],
         [['--shift', '-s'], {'type': float, 'default': 0.5, 'help': desc['shift']}]

--- a/dicelib/scripts/dice_tractogram.py
+++ b/dicelib/scripts/dice_tractogram.py
@@ -444,7 +444,7 @@ def coherence():
         [['sph_func'], {'help': desc['sph_func_filename']}],
         [['out_weights'], {'help': desc['out_weights_filename']}],
         [['--stat'], {'choices': ['min','mean','max', 'all'], 'default': 'min', 'help': desc['stat']}],
-        [['--normalize', '-n'], {'action': 'store_true', 'help': desc['normalize']}],
+        [['--normalize', '-n'], {'type': str, 'default': None, 'help': desc['lobes_filename']}],
         [['--trim', '-t'], {'type': float, 'default': 0.05, 'help': desc['trim']}],
         [['--shift', '-s'], {'type': float, 'default': 0.5, 'help': desc['shift']}]
     ]
@@ -455,7 +455,7 @@ def coherence():
             sph_func_filename=options.sph_func,
             out_weights_filename=options.out_weights,
             stat=options.stat,
-            normalize=options.normalize,
+            lobes_filename=options.normalize,
             trim=options.trim,
             shift=options.shift,
             force=options.force,

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -661,16 +661,14 @@ def filter( tractogram_filename: str, out_tractogram_filename: str, weights_file
                 logger.error(f'Number of weights ({w.size}) is different from number of streamlines')
         else:
             w = np.array([])
-        # load the (eventual) track scalars
+        # load the track scalars (if any)
         if scalars_filename is not None:
             TSF_in  = TrackScalarFile( scalars_filename, mode='r' )
             TSF_out = TrackScalarFile( out_scalars_filename, mode='w', header=TSF_in.header )
 
         #----- iterate over input streamlines -----
         with ProgressBar( total=2*n_streamlines, disable=verbose < 3, hide_on_exit=True) as pbar:
-            # check if #(weights_filename)==n_streamlines
             kept = np.ones( n_streamlines, dtype=bool )
-
             for i in range( n_streamlines ):
                 TCK_in.read_streamline()
                 if TCK_in.n_pts==0:
@@ -687,13 +685,10 @@ def filter( tractogram_filename: str, out_tractogram_filename: str, weights_file
                         continue
 
                 # filter by weight
-                if weights_filename is not None and (
-                    (minweight is not None and w[i]<minweight) or
-                    (maxweight is not None and w[i]>maxweight)
-                ):
-                    kept[i] = False
-                    continue
-
+                if weights_filename is not None:
+                    if (minweight is not None and w[i]<minweight) or (maxweight is not None and w[i]>maxweight):
+                        kept[i] = False
+                        continue
                 pbar.update()
 
             if random < 1:
@@ -704,10 +699,12 @@ def filter( tractogram_filename: str, out_tractogram_filename: str, weights_file
             TCK_in._seek_origin(int(TCK_in.header['file'][2:])) # move position back to data
             for i in range( n_streamlines ):
                 TCK_in.read_streamline()
-                TSF_in.read_scalars()
+                if scalars_filename is not None:
+                    TSF_in.read_scalars()
                 if kept[i]:
                     TCK_out.write_streamline( TCK_in.streamline, TCK_in.n_pts )
-                    TSF_out.write_scalars( TSF_in.scalars, TSF_in.n_pts )
+                    if scalars_filename is not None:
+                        TSF_out.write_scalars( TSF_in.scalars, TSF_in.n_pts )
                     n_written += 1
                 pbar.update()
 
@@ -716,7 +713,6 @@ def filter( tractogram_filename: str, out_tractogram_filename: str, weights_file
                     np.savetxt(out_weights_filename, w[kept == True].astype(np.float32), fmt='%.5e')
                 else:
                     np.save(out_weights_filename, w[kept == True].astype(np.float32), allow_pickle=False)
-
 
     except Exception as e:
         if os.path.isfile( out_tractogram_filename ):

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -2,21 +2,18 @@
 cimport cython
 import warnings
 warnings.filterwarnings('ignore', module='dipy')
-
 from libc.math cimport isinf, isnan, NAN, sqrt, atan2, M_PI, round, floor
 from libc.stdio cimport fclose, fgets, fopen, fread, fseek, fwrite, SEEK_CUR, SEEK_END, SEEK_SET
 from libc.stdlib cimport malloc, free
 from libcpp cimport bool as cbool
 from libc.string cimport strchr, strlen, strncmp
 from libcpp.string cimport string
-
 from dicelib.streamline import apply_smoothing, length as streamline_length, rdp_reduction, resample as s_resample, set_number_of_points, smooth, create_streamline_replicas
 from dicelib.streamline cimport apply_affine_1pt
 from dicelib.ui import ProgressBar, set_verbose, setup_logger
 from dicelib.utils import check_params, Dir, File, Num, format_time
 from dicelib.connectivity import assign
 from dicelib.tsf cimport TrackScalarFile
-
 import ast, random as rnd
 import os, sys, shutil
 import nibabel as nib
@@ -2222,7 +2219,7 @@ cpdef save_replicas(input_tractogram: str, output_tractogram: str, blur_core_ext
         tmp = np.arange(0,blur_core_extent+blur_gauss_extent+1e-6,blur_spacing)
         tmp = np.concatenate( (tmp,-tmp[1:][::-1]) )
         x, y = np.meshgrid( tmp, tmp )
-        r = np.sqrt( x*x + y*y )
+        r = sqrt( x*x + y*y )
         idx = (r <= blur_core_extent+blur_gauss_extent)
         blurRho = r[idx]
         blurAngle = np.arctan2(y,x)[idx]
@@ -2232,7 +2229,7 @@ cpdef save_replicas(input_tractogram: str, output_tractogram: str, blur_core_ext
         if blur_gauss_extent == 0 :
             blurWeights[:] = 1.0
         else:
-            blur_sigma = blur_gauss_extent / np.sqrt( -2.0 * np.log( blur_gauss_min ) )
+            blur_sigma = blur_gauss_extent / sqrt( -2.0 * np.log( blur_gauss_min ) )
             for i in xrange(nReplicas):
                 if blurRho[i] <= blur_core_extent :
                     blurWeights[i] = 1.0
@@ -2375,7 +2372,7 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
         niiSF_img = np.ascontiguousarray(niiSF.get_fdata(), dtype=np.float32)
         logger.subinfo(f'Spherical functions: {niiSF.shape[0]}x{niiSF.shape[1]}x{niiSF.shape[2]}x{niiSF.shape[3]}', indent_char='*', indent_lvl=1)
         n_sh_coeff = niiSF_img.shape[3]
-        lmax = (-3.0 + np.sqrt(1+8*n_sh_coeff)) / 2
+        lmax = (-3.0 + sqrt(1+8*n_sh_coeff)) / 2
         if not lmax.is_integer() :
             logger.error( f'The number of coefficients ({n_sh_coeff}) is not compatible with any SH basis' )
         lmax = int(lmax)

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -2315,7 +2315,7 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     normalize : boolean, default=False
         Normalize spherical function in each voxel to its maximum value.
     trim : float, default=0.05
-        Percentage of points to skip at each extremity.
+        Percentage of segments to skip at each extremity.
     shift : float, default=0.5
         If necessary, apply a shift (in voxel units) to streamline coordinates to
         account for differences between software packages.

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -2,7 +2,7 @@
 cimport cython
 import warnings
 warnings.filterwarnings('ignore', module='dipy')
-from libc.math cimport isinf, isnan, NAN, sqrt, atan2, M_PI, round, floor
+from libc.math cimport isinf, isnan, NAN, sqrt, atan2, M_PI, round, floor, acos
 from libc.stdio cimport fclose, fgets, fopen, fread, fseek, fwrite, SEEK_CUR, SEEK_END, SEEK_SET
 from libc.stdlib cimport malloc, free
 from libcpp cimport bool as cbool
@@ -2285,7 +2285,7 @@ cpdef save_replicas(input_tractogram: str, output_tractogram: str, blur_core_ext
     logger.info( f'[ {format_time(t1 - t0)} ]' )
 
 
-cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_weights_filename: str=None, stat: str='min', normalize: bool=False, trim: float=0.05, shift: float=0.5, force: bool=False, verbose: int=3 ):
+cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_weights_filename: str=None, stat: str='min', lobes_filename: str=None, trim: float=0.05, shift: float=0.5, force: bool=False, verbose: int=3 ):
     """Compute the coherence of streamlines with a voxelwise spherical function (e.g. FOD).
 
     The file containing the spherical functions should follow the MrTrix3 conventions
@@ -2302,9 +2302,14 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
         Path to the file (.txt, .npy, .tsf) that will contain the estimated coherence weights.
     stat : {'min', 'mean', 'max', 'all'}, default='min'
         Summary statistic to use once the coherence is computed for all segments of a streamline.
-        If 'all' is specified, the coherence of each segment will be saved in a .tsf file; otherwise, the summary statistic will be saved in a .txt or .npy file. When a .tsf file is produced, each point of a streamline is assigned a weight corresponding to the average coherence of the segments centered on that point. For the first and last points, the weight is computed using only the following or preceding segment, respectively.
-    normalize : boolean, default=False
-        Normalize spherical function in each voxel to its maximum value.
+        If 'all' is specified, the coherence of each segment will be saved in a .tsf file;
+        otherwise, the summary statistic will be saved in a .txt or .npy file.
+        When a .tsf file is produced, each point of a streamline is assigned a weight corresponding
+        to the average coherence of the segments centered on that point. For the first and last points,
+        the weight is computed using only the following or preceding segment, respectively.
+    lobes_filename : string, optional
+        Path to the file (.nii, .nii.gz) containing the peaks that identify the lobes of the spherical functions, which
+        will be used to normalize the local coherence by the value of the corresponding lobe.
     trim : float, default=0.05
         Percentage of segments to skip at each extremity.
     shift : float, default=0.5
@@ -2328,16 +2333,19 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     cdef float [:] p2 = np.zeros(3, dtype=np.float32)
     cdef float [:] dir = np.zeros(3, dtype=np.float32)
     cdef float [:,:,:,::1] niiSF_img
-    cdef float [:,::1] SHbasis
+    cdef float [:,:,:,::1] niiPEAKS_img
+    cdef float [:,::1] sh_basis, dirs_angles
     cdef short [:] htable
     cdef float [::1] sf_voxel = np.zeros(500, dtype=np.float32)
-    cdef float [:] coherence, coherence_tsf
+    cdef float [:] coherence, dirs_angles_voxel
+    cdef float [:] coherence_tsf = np.zeros(10000, dtype=np.float32)
+    cdef int [:] peaks_idx
     cdef double [:,::1] affine_inv
     cdef LazyTractogram TCK_in = None
     cdef TrackScalarFile TSF_out = None
-    cdef int ox, oy, o, trim_offset, n
-    cdef int vx, vy, vz, i, j, k
-    cdef float val
+    cdef int ox, oy, o, o2, trim_offset, n
+    cdef int vx, vy, vz, i, j, k, n_peaks=0, peaks_found
+    cdef float sf_val1, sf_val2
     cdef float *ptr1, *ptr2
 
     t0 = time()
@@ -2351,6 +2359,8 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
             files.append(File(name='out_weights_filename', type_='output', path=out_weights_filename, ext=['.tsf']))
         else:
             files.append(File(name='out_weights_filename', type_='output', path=out_weights_filename, ext=['.txt', '.npy']))
+    if lobes_filename is not None:
+        files.append(File(name='lobes_filename', type_='input', path=lobes_filename, ext=['.nii', '.nii.gz']))
     check_params(files=files, force=force)
 
     if trim<0 or trim>=0.5:
@@ -2358,7 +2368,6 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     if stat not in ['min','mean','max','all']:
         logger.error('"stat" must be one of [min, mean, max, all]')
 
-    #----- iterate over input streamlines -----
     try:
         # open tractogram
         TCK_in = LazyTractogram( tractogram_filename, mode='r' )
@@ -2368,39 +2377,62 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
         logger.subinfo(f'Number of streamlines: {n_streamlines}', indent_char='*', indent_lvl=1)
         if n_streamlines <= 0:
             logger.error('The tractogram is empty')
+        logger.subinfo(f'Shifting coordinates by {shift:.1f} voxel', indent_char='*', indent_lvl=1)
+        logger.subinfo(f'Trimming {trim*100:.1f}% of segments at each extremity', indent_char='*', indent_lvl=1)
 
         # open spherical functions
         niiSF = nib.load( sph_func_filename )
         niiSF_img = np.ascontiguousarray(niiSF.get_fdata(), dtype=np.float32)
-        logger.subinfo(f'Spherical functions: {niiSF.shape[0]}x{niiSF.shape[1]}x{niiSF.shape[2]}x{niiSF.shape[3]}', indent_char='*', indent_lvl=1)
         n_sh_coeff = niiSF_img.shape[3]
         lmax = (-3.0 + sqrt(1+8*n_sh_coeff)) / 2
         if not lmax.is_integer() :
             logger.error( f'The number of coefficients ({n_sh_coeff}) is not compatible with any SH basis' )
         lmax = int(lmax)
         affine_inv  = np.linalg.inv(niiSF.affine)
+        logger.subinfo(f'Spherical functions order: {lmax:.0f}', indent_char='*', indent_lvl=1)
 
         # construct the SH basis to sample the spherical function
-        # (using the 500 directions/hash table used internally by COMMIT)
+        # (using the 500 directions/hash table used internally by COMMIT/AMICO)
+        logger.debug( 'Computing SH basis' )
         dirs  = amico.lut.load_directions( 500 )
         logger.debug( f'directions: {dirs.shape[0]}x{dirs.shape[1]}'  )
         htable = amico.lut.load_precomputed_hash_table( 500 )
         logger.debug( f'hash table: {htable.shape[0]}x1 [min={np.min(htable)}, max={np.max(htable)}]'  )
-        theta = np.zeros( dirs.shape[0] )
-        phi = np.zeros( dirs.shape[0] )
+        theta = np.zeros(dirs.shape[0])
+        phi = np.zeros(dirs.shape[0])
         for i in range(theta.size):
-            phi[i] = atan2(dirs[i,1], dirs[i,0])#/M_PI*180.0
-            theta[i] = atan2( sqrt(dirs[i,0]*dirs[i,0]+dirs[i,1]*dirs[i,1]), dirs[i,2] )#/M_PI*180.0
+            phi[i] = atan2(dirs[i,1], dirs[i,0])
+            theta[i] = atan2(sqrt(dirs[i,0]*dirs[i,0]+dirs[i,1]*dirs[i,1]), dirs[i,2])
+            dirs[i,:] /= np.linalg.norm(dirs[i,:]) # normalize for later computation
         tmp, _, _ = real_sh_tournier(lmax, theta, phi)
-        SHbasis = np.asarray(tmp, dtype=np.float32)
-        del dirs, theta, phi, tmp
+        sh_basis = np.asarray(tmp, dtype=np.float32)
+        del theta, phi, tmp
 
-        logger.subinfo(f'Coordinates shifted by {shift:.1f} voxel', indent_char='*', indent_lvl=1)
-        logger.subinfo(f'Trimmed {trim*100:.1f}% of segments at each extremity', indent_char='*', indent_lvl=1)
-        logger.subinfo(f'Normalization: {normalize}', indent_char='*', indent_lvl=1)
+        # open lobes for normalization
+        niiPEAKS = None
+        if lobes_filename is not None:
+            logger.subinfo('Normalizing by lobes', indent_char='*', indent_lvl=1)
+            niiPEAKS = nib.load( lobes_filename )
+            niiPEAKS_img = np.ascontiguousarray(niiPEAKS.get_fdata(), dtype=np.float32)
+            logger.debug(f'Peaks of the lobes: {niiPEAKS.shape[0]}x{niiPEAKS.shape[1]}x{niiPEAKS.shape[2]}x{niiPEAKS.shape[3]}')
+            if niiPEAKS.shape[:3] != niiSF.shape[:3]:
+                logger.error( f'The shape of the PEAKS dataset is not compatible with the SPHERICAL FUNCTIONS' )
+            if niiPEAKS.shape[3] % 3:
+                logger.error( 'PEAKS dataset must have 3*k volumes' )
+            n_peaks = niiPEAKS.shape[3]/3
+            dirs_angles_voxel = np.zeros(n_peaks, dtype=np.float32)
+            logger.debug( 'Computing angles between 500 directions' )
+            dirs_angles = np.zeros((500,500), dtype=np.float32)
+            for i in range(500):
+                for j in range(i+1,500):
+                    dirs_angles[i,j] = acos(dirs[i,0]*dirs[j,0]+dirs[i,1]*dirs[j,1]+dirs[i,2]*dirs[j,2])
+                    dirs_angles[j,i] = dirs_angles[i,j]
+            peaks_idx = np.zeros(n_peaks, np.int32)
+        del dirs
+
         logger.subinfo(f'Summary statistic along streamlines: "{stat}"', indent_char='*', indent_lvl=1)
 
-        # process every streamline
+        #----- process every streamline -----
         coherence = np.zeros( n_streamlines, dtype=np.float32 )
         if n_streamlines>0:
             with ProgressBar( total=n_streamlines, disable=verbose < 3, hide_on_exit=True) as pbar:
@@ -2408,8 +2440,10 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                     TCK_in.read_streamline()
                     if TCK_in.n_pts==0:
                         break # no more data, stop reading
+                    if TCK_in.n_pts>10000:
+                        logger.error( 'The streamline {i} contains too many points ({TCK_in.n_pts})' )
 
-                    trim_offset = int( floor((TCK_in.n_pts-1)*trim) ) # skip 'trim' percent of segments
+                    trim_offset = int( round((TCK_in.n_pts-1)*trim) ) # skip 'trim' percent of segments
                     if TCK_in.n_pts - trim_offset*2 <=0 :
                         logger.warning( f'"trim" too high, streamline {i} is empty; coherence set to 0' )
                         coherence[i] = 0
@@ -2417,7 +2451,7 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
 
                     apply_affine_1pt(TCK_in.streamline[trim_offset], affine_inv, p1, shift)
                     n = 0
-                    for j in range(trim_offset+1,TCK_in.n_pts-trim_offset+1):
+                    for j in range(trim_offset+1,TCK_in.n_pts-trim_offset):
                         # get direction of current segment
                         apply_affine_1pt(TCK_in.streamline[j], affine_inv, p2, shift)
                         dir[1] = p2[1]-p1[1]
@@ -2430,36 +2464,48 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                             dir[0] = p2[0]-p1[0]
                             dir[2] = p2[2]-p1[2]
 
-                        # get the closest direction from the 500 internally used by COMMIT/AMICO
+                        # round to the closest direction among the canonical 500 internally used by AMICO/COMMIT
                         ox = int( round(atan2( sqrt(dir[0]*dir[0]+dir[1]*dir[1]), dir[2] )/M_PI*180.0) )
                         oy = int( round(atan2( dir[1], dir[0] )/M_PI*180.0) )
-                        o = htable[ox*181 + oy]
-                        if o<0 or o>=500:
-                            logger.error( f'This should not happen: o={o}, ox={ox}, oy={oy}' )
+                        o = htable[ox*181+oy]
 
-                        # check alignment of current segment to spherical function in current voxel
+                        # evaluate the SF along this direction (i.e. sh_basis[o,:] @ niiSF_img[vx,vy,vz,:])
                         vx = int( floor(0.5*(p2[0]+p1[0])) )
                         vy = int( floor(0.5*(p2[1]+p1[1])) )
                         vz = int( floor(0.5*(p2[2]+p1[2])) )
-                        if normalize == False:
-                            # compute SHbasis[o,:] @ niiSF_img[vx,vy,vz,:]
-                            ptr1 = &SHbasis[o,0]
-                            ptr2 = &niiSF_img[vx,vy,vz,0]
-                            val = 0
-                            for k in range(n_sh_coeff):
-                                val += ptr1[k]*ptr2[k]
-                            w[n] = val
-                        else:
-                            # normalize by the max value in the voxel
-                            sf_voxel = np.dot(SHbasis, niiSF_img[vx,vy,vz,:])
-                            val = np.max( sf_voxel )
-                            if val > 0:
-                                w[n] = sf_voxel[o] / val
-                            else:
-                                w[n] = 0
-                        # crop to zero negative values
-                        if w[n] < 0:
-                            w[n] = 0
+                        ptr1 = &niiSF_img[vx,vy,vz,0]
+                        ptr2 = &sh_basis[o,0]
+                        sf_val1 = 0
+                        for k in range(n_sh_coeff):
+                            sf_val1 += ptr1[k]*ptr2[k]
+                        if sf_val1 < 0.0:
+                            sf_val1 = 0.0
+
+                        # normalize by corresponding lobe
+                        if n_peaks > 0:
+                            ptr2 = &niiPEAKS_img[vx,vy,vz,0]
+                            peaks_found = 0
+                            for k in range(n_peaks):
+                                if isnan(ptr2[0]):# or (ptr2[0]==0 and ptr2[1]==0 and ptr2[2]==0):
+                                    break
+                                peaks_found += 1
+                                ox = int( round(atan2( sqrt(ptr2[0]*ptr2[0]+ptr2[1]*ptr2[1]), ptr2[2] )/M_PI*180.0) )
+                                oy = int( round(atan2( ptr2[1], ptr2[0] )/M_PI*180.0) )
+                                o2 = htable[ox*181+oy]
+                                dirs_angles_voxel[k] = dirs_angles[o,o2] # angle between segment and k-th lobe
+                                peaks_idx[k] = o2
+                                ptr2 += 3
+
+                            if peaks_found>0:
+                                k = peaks_idx[ np.argmin(dirs_angles_voxel[:peaks_found]) ]
+                                ptr2 = &sh_basis[k,0]
+                                sf_val2 = 0
+                                for k in range(n_sh_coeff):
+                                    sf_val2 += ptr1[k]*ptr2[k]
+                                if sf_val2 > 0.0:
+                                    sf_val1 /= sf_val2
+                        w[n] = sf_val1 if sf_val1>0 else 0
+
                         p1[0] = p2[0]
                         p1[1] = p2[1]
                         p1[2] = p2[2]
@@ -2468,18 +2514,16 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                     if stat=='min':
                         coherence[i] = np.min(w[:n])
                     elif stat=='mean':
-                        coherence[i] = np.mean( w[:n] )
+                        coherence[i] = np.mean(w[:n])
                     elif stat=='max':
-                        coherence[i] = np.max( w[:n] )
+                        coherence[i] = np.max(w[:n])
                     elif stat=='all':
-                        coherence_tsf = np.full(TCK_in.n_pts, -1, dtype=np.float32)
-                        for j in range(n):
-                            if j == 0:
-                                coherence_tsf[j+trim_offset] = w[j]
-                            elif j == n-1:
-                                coherence_tsf[j+trim_offset] = w[j]
-                            else:
-                                coherence_tsf[j+trim_offset] = (w[j-1]+w[j])/2
+                        coherence_tsf[:trim_offset] = -1
+                        coherence_tsf[trim_offset] = w[0]
+                        for j in range(n-1):
+                            coherence_tsf[trim_offset+j+1] = (w[j]+w[j+1])/2.0
+                        coherence_tsf[TCK_in.n_pts-trim_offset-1] = w[n-1]
+                        coherence_tsf[TCK_in.n_pts-trim_offset:] = -1
                         TSF_out.write_scalars( coherence_tsf, TCK_in.n_pts )
 
                     pbar.update()

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -2333,14 +2333,18 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     cdef float [:] p1 = np.zeros(3, dtype=np.float32)
     cdef float [:] p2 = np.zeros(3, dtype=np.float32)
     cdef float [:] dir = np.zeros(3, dtype=np.float32)
-    cdef float m
-    cdef int ox, oy, o, trim_offset, n
-    cdef int vx, vy, vz
+    cdef float [:,:,:,::1] niiSF_img
     cdef float [:,::1] SHbasis
     cdef short [:] htable
-    cdef float [:] P, coherence, sf_voxel, coherence_tsf
+    cdef float [:] sf_voxel = np.zeros(500, dtype=np.float32)
+    cdef float [:] coherence, coherence_tsf
     cdef double [:,::1] affine_inv
-    cdef TrackScalarFile TSF_out
+    cdef LazyTractogram TCK_in = None
+    cdef TrackScalarFile TSF_out = None
+    cdef int ox, oy, o, trim_offset, n
+    cdef int vx, vy, vz, i, j, k
+    cdef float val
+    cdef float *ptr1, *ptr2
 
     t0 = time()
     set_verbose('tractogram', verbose)
@@ -2361,7 +2365,6 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
         logger.error('"stat" must be one of [min, mean, max, all]')
 
     #----- iterate over input streamlines -----
-    TCK_in = None
     try:
         # open tractogram
         TCK_in = LazyTractogram( tractogram_filename, mode='r' )
@@ -2418,25 +2421,20 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                         coherence[i] = 0
                         continue
 
-                    P = TCK_in.streamline[trim_offset]
-                    apply_affine_1pt(P, affine_inv, p1, shift)
+                    apply_affine_1pt(TCK_in.streamline[trim_offset], affine_inv, p1, shift)
                     n = 0
                     for j in range(trim_offset+1,TCK_in.n_pts-trim_offset+1):
-                        P = TCK_in.streamline[j]
-                        apply_affine_1pt(P, affine_inv, p2, shift)
-                        vx = int( floor(0.5*(p2[0]+p1[0])) )
-                        vy = int( floor(0.5*(p2[1]+p1[1])) )
-                        vz = int( floor(0.5*(p2[2]+p1[2])) )
-
-                        # check if dir[1] is negative and flip (because hash tables cover half sphere)
+                        # get direction of current segment
+                        apply_affine_1pt(TCK_in.streamline[j], affine_inv, p2, shift)
                         dir[1] = p2[1]-p1[1]
-                        if dir[1] >= 0:
-                            dir[0] = p2[0]-p1[0]
-                            dir[2] = p2[2]-p1[2]
-                        else:
+                        if dir[1] < 0:
+                            # flip direction as hash tables cover half sphere
                             dir[1] = -dir[1]
                             dir[0] = p1[0]-p2[0]
                             dir[2] = p1[2]-p2[2]
+                        else:
+                            dir[0] = p2[0]-p1[0]
+                            dir[2] = p2[2]-p1[2]
 
                         # get the closest direction from the 500 internally used by COMMIT/AMICO
                         ox = int( round(atan2( sqrt(dir[0]*dir[0]+dir[1]*dir[1]), dir[2] )/M_PI*180.0) )
@@ -2445,11 +2443,20 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                         if o<0 or o>=500:
                             logger.error( f'This should not happen: o={o}, ox={ox}, oy={oy}' )
 
-                        # check alignment of local orientation to spherical function in current voxel
+                        # check alignment of current segment to spherical function in current voxel
+                        vx = int( floor(0.5*(p2[0]+p1[0])) )
+                        vy = int( floor(0.5*(p2[1]+p1[1])) )
+                        vz = int( floor(0.5*(p2[2]+p1[2])) )
                         if normalize == False:
-                            w[n] = SHbasis[o,:] @ niiSF_img[vx,vy,vz,:]
+                            # computes SHbasis[o,:] @ niiSF_img[vx,vy,vz,:]
+                            ptr1 = &SHbasis[o,0]
+                            ptr2 = &niiSF_img[vx,vy,vz,0]
+                            val = 0
+                            for k in range(n_sh_coeff):
+                                val += ptr1[k]*ptr2[k]
+                            w[n] = val
                         else:
-                            sf_voxel = SHbasis @ niiSF_img[vx,vy,vz,:]
+                            sf_voxel = np.dot(SHbasis, niiSF_img[vx,vy,vz,:])
                             m = np.max( sf_voxel )
                             if m > 0:
                                 w[n] = sf_voxel[o] / m # normalization by the max value in the voxel
@@ -2465,22 +2472,20 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                         n += 1
 
                     if stat=='min':
-                        coherence[i] = np.nanmin( w[:n] )
+                        coherence[i] = np.min(w[:n])
                     elif stat=='mean':
-                        coherence[i] = np.nanmean( w[:n] )
+                        coherence[i] = np.mean( w[:n] )
                     elif stat=='max':
-                        coherence[i] = np.nanmax( w[:n] )
+                        coherence[i] = np.max( w[:n] )
                     elif stat=='all':
                         coherence_tsf = np.full(TCK_in.n_pts, -1, dtype=np.float32)
-                        for x in range(n):
-                            if x == 0:
-                                coherence_tsf[x+trim_offset] = w[x]
-                            elif x == n-1:
-                                coherence_tsf[x+trim_offset] = w[x]
+                        for j in range(n):
+                            if j == 0:
+                                coherence_tsf[j+trim_offset] = w[j]
+                            elif j == n-1:
+                                coherence_tsf[j+trim_offset] = w[j]
                             else:
-                                coherence_tsf[x+trim_offset] = (w[x-1]+w[x])/2
-                        # print([i for i in coherence_tsf])
-                        # print(f' \n \n ')
+                                coherence_tsf[j+trim_offset] = (w[j-1]+w[j])/2
                         TSF_out.write_scalars( coherence_tsf, TCK_in.n_pts )
 
                     pbar.update()
@@ -2536,6 +2541,7 @@ cpdef compute_tdi( tractogram_filename: str, ref_image_filename: str, out_map_fi
     cdef float [:] P
     cdef double [:,::1] affine_inv
     cdef float [:,:,::1] niiTDI_img
+    cdef int vx, vy, vz
 
     files = [File(name='tractogram_filename', type_='input', path=tractogram_filename, ext=['.tck'])]
     files.append(File(name='ref_image_filename', type_='input', path=ref_image_filename, ext=['.nii','.nii.gz']))

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -17,15 +17,11 @@ from dicelib.utils import check_params, Dir, File, Num, format_time
 from dicelib.connectivity import assign
 from dicelib.tsf cimport TrackScalarFile
 
-import amico.lut
 import ast, random as rnd
 import os, sys, shutil
 import nibabel as nib
 import numpy as np
 from time import time
-
-from dipy.reconst.shm import real_sh_tournier
-#TODO: remove DIPY dependency (currently, required for only 1 function)
 
 cdef float[1] NAN1 = {NAN}
 cdef float[3] NAN3 = {NAN, NAN, NAN}
@@ -2325,6 +2321,9 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     array of float
         The estimate coherence weights for all input streamlines.
     """
+    import amico.lut
+    from dipy.reconst.shm import real_sh_tournier
+    #TODO: remove DIPY dependency (currently, required for only 1 function)
     cdef float [::1] w = np.zeros(10000, dtype=np.float32) #NOTE: assume max length of a streamline = 10000
     cdef float [:] p1 = np.zeros(3, dtype=np.float32)
     cdef float [:] p2 = np.zeros(3, dtype=np.float32)

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -102,6 +102,8 @@ cdef class LazyTractogram:
             self._read_header()
         elif self.mode=='w':
             # file is open for writing => need to write a header to disk
+            if header is None:
+                header = {'datatype': 'Float32LE', 'timestamp': str(time()), 'count': '0'}
             self._write_header( header )
         else:
             # file is open for appending => move pointer to end
@@ -2219,7 +2221,7 @@ cpdef save_replicas(input_tractogram: str, output_tractogram: str, blur_core_ext
         tmp = np.arange(0,blur_core_extent+blur_gauss_extent+1e-6,blur_spacing)
         tmp = np.concatenate( (tmp,-tmp[1:][::-1]) )
         x, y = np.meshgrid( tmp, tmp )
-        r = sqrt( x*x + y*y )
+        r = np.sqrt( x*x + y*y )
         idx = (r <= blur_core_extent+blur_gauss_extent)
         blurRho = r[idx]
         blurAngle = np.arctan2(y,x)[idx]
@@ -2229,7 +2231,7 @@ cpdef save_replicas(input_tractogram: str, output_tractogram: str, blur_core_ext
         if blur_gauss_extent == 0 :
             blurWeights[:] = 1.0
         else:
-            blur_sigma = blur_gauss_extent / sqrt( -2.0 * np.log( blur_gauss_min ) )
+            blur_sigma = blur_gauss_extent / np.sqrt( -2.0 * np.log( blur_gauss_min ) )
             for i in xrange(nReplicas):
                 if blurRho[i] <= blur_core_extent :
                     blurWeights[i] = 1.0

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -2328,17 +2328,19 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     import amico.lut
     from dipy.reconst.shm import real_sh_tournier
     #TODO: remove DIPY dependency (currently, required for only 1 function)
-    cdef float [::1] w = np.zeros(10000, dtype=np.float32) #NOTE: assume max length of a streamline = 10000
-    cdef float [:] p1 = np.zeros(3, dtype=np.float32)
-    cdef float [:] p2 = np.zeros(3, dtype=np.float32)
-    cdef float [:] dir = np.zeros(3, dtype=np.float32)
+    cdef float [::1] w = np.empty(10000, dtype=np.float32) #NOTE: assume max length of a streamline = 10000
+    cdef float [:] p1 = np.empty(3, dtype=np.float32)
+    cdef float [:] p2 = np.empty(3, dtype=np.float32)
+    cdef float [:] dir = np.empty(3, dtype=np.float32)
+    cdef short [:] htable
     cdef float [:,:,:,::1] niiSF_img
     cdef float [:,:,:,::1] niiPEAKS_img
-    cdef float [:,::1] sh_basis, dirs_angles
-    cdef short [:] htable
-    cdef float [::1] sf_voxel = np.zeros(500, dtype=np.float32)
-    cdef float [:] coherence, dirs_angles_voxel
-    cdef float [:] coherence_tsf = np.zeros(10000, dtype=np.float32)
+    cdef float [:,::1] sh_basis
+    cdef float [:,::1] dirs_angles = np.zeros((500,500), dtype=np.float32)
+    cdef float [:] dirs_angles_voxel
+    cdef float [::1] sf_voxel = np.empty(500, dtype=np.float32)
+    cdef float [:] coherence
+    cdef float [:] coherence_tsf = np.empty(10000, dtype=np.float32)
     cdef int [:] peaks_idx
     cdef double [:,::1] affine_inv
     cdef LazyTractogram TCK_in = None
@@ -2422,12 +2424,11 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
             n_peaks = niiPEAKS.shape[3]/3
             dirs_angles_voxel = np.zeros(n_peaks, dtype=np.float32)
             logger.debug( 'Computing angles between 500 directions' )
-            dirs_angles = np.zeros((500,500), dtype=np.float32)
             for i in range(500):
                 for j in range(i+1,500):
                     dirs_angles[i,j] = acos(dirs[i,0]*dirs[j,0]+dirs[i,1]*dirs[j,1]+dirs[i,2]*dirs[j,2])
                     dirs_angles[j,i] = dirs_angles[i,j]
-            peaks_idx = np.zeros(n_peaks, np.int32)
+            peaks_idx = np.zeros(n_peaks, dtype=np.int32)
         del dirs
 
         logger.subinfo(f'Summary statistic along streamlines: "{stat}"', indent_char='*', indent_lvl=1)
@@ -2454,9 +2455,10 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                     for j in range(trim_offset+1,TCK_in.n_pts-trim_offset):
                         # get direction of current segment
                         apply_affine_1pt(TCK_in.streamline[j], affine_inv, p2, shift)
+
+                        # compute polar angles (NB: hash tables cover half sphere)
                         dir[1] = p2[1]-p1[1]
                         if dir[1] < 0:
-                            # flip direction as hash tables cover half sphere
                             dir[1] = -dir[1]
                             dir[0] = p1[0]-p2[0]
                             dir[2] = p1[2]-p2[2]
@@ -2489,9 +2491,17 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                                 if isnan(ptr2[0]):# or (ptr2[0]==0 and ptr2[1]==0 and ptr2[2]==0):
                                     break
                                 peaks_found += 1
-                                ox = int( round(atan2( sqrt(ptr2[0]*ptr2[0]+ptr2[1]*ptr2[1]), ptr2[2] )/M_PI*180.0) )
-                                oy = int( round(atan2( ptr2[1], ptr2[0] )/M_PI*180.0) )
+
+                                # compute polar angles (NB: hash tables cover half sphere)
+                                if ptr2[1] > 0:
+                                    ox = int( round(atan2( sqrt(ptr2[0]*ptr2[0]+ptr2[1]*ptr2[1]), ptr2[2] )/M_PI*180.0) )
+                                    oy = int( round(atan2( ptr2[1], ptr2[0] )/M_PI*180.0) )
+                                else:
+                                    ox = int( round(atan2( sqrt(ptr2[0]*ptr2[0]+ptr2[1]*ptr2[1]), -ptr2[2] )/M_PI*180.0) )
+                                    oy = int( round(atan2( -ptr2[1], -ptr2[0] )/M_PI*180.0) )
                                 o2 = htable[ox*181+oy]
+                                if o<0 or o>=500 or o2<0 or o2>=500:
+                                    logger.error( f'This should not happen: o={o} o2={o2}' )
                                 dirs_angles_voxel[k] = dirs_angles[o,o2] # angle between segment and k-th lobe
                                 peaks_idx[k] = o2
                                 ptr2 += 3
@@ -2502,14 +2512,19 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                                 sf_val2 = 0
                                 for k in range(n_sh_coeff):
                                     sf_val2 += ptr1[k]*ptr2[k]
-                                if sf_val2 > 0.0:
+                                if sf_val2 < 0.0:
+                                    sf_val2 = 0.0
+                                if sf_val2 > sf_val1:
                                     sf_val1 /= sf_val2
+                                else:
+                                    sf_val1 = 1.0 # crop top 1
                         w[n] = sf_val1 if sf_val1>0 else 0
+                        n += 1
 
+                        # process next coordinate along streamline
                         p1[0] = p2[0]
                         p1[1] = p2[1]
                         p1[2] = p2[2]
-                        n += 1
 
                     if stat=='min':
                         coherence[i] = np.min(w[:n])

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -2308,9 +2308,10 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     sph_func_filename : str
         Path to the file (.nii, .nii.gz) containing the spherical function against which each streamline is evaluated.
     out_weights_filename : str
-        Path to the file (.txt, .npy) that will contain the estimated coherence weights.
-    stat : {'min', 'mean', 'max'}, default='min'
+        Path to the file (.txt, .npy, .tsf) that will contain the estimated coherence weights.
+    stat : {'min', 'mean', 'max', 'all'}, default='min'
         Summary statistic to use once the coherence is computed for all segments of a streamline.
+        If 'all' is specified, the coherence of each segment will be saved in a .tsf file; otherwise, the summary statistic will be saved in a .txt or .npy file. When a .tsf file is produced, each point of a streamline is assigned a weight corresponding to the average coherence of the segments centered on that point. For the first and last points, the weight is computed using only the following or preceding segment, respectively.
     normalize : boolean, default=False
         Normalize spherical function in each voxel to its maximum value.
     trim : float, default=0.05
@@ -2328,7 +2329,7 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     array of float
         The estimate coherence weights for all input streamlines.
     """
-    cdef float [::1] w = np.zeros(10000, dtype=np.float32) #NOTE: assume max length of a streamline = 10000
+    cdef float [::1] w = np.full(10000, -1, dtype=np.float32) #NOTE: assume max length of a streamline = 10000
     cdef float [:] p1 = np.zeros(3, dtype=np.float32)
     cdef float [:] p2 = np.zeros(3, dtype=np.float32)
     cdef float [:] dir = np.zeros(3, dtype=np.float32)
@@ -2337,8 +2338,9 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     cdef int vx, vy, vz
     cdef float [:,::1] SHbasis
     cdef short [:] htable
-    cdef float [:] P, coherence, sf_voxel
+    cdef float [:] P, coherence, sf_voxel, coherence_tsf
     cdef double [:,::1] affine_inv
+    cdef TrackScalarFile TSF_out
 
     t0 = time()
     set_verbose('tractogram', verbose)
@@ -2347,13 +2349,16 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     files = [File(name='tractogram_filename', type_='input', path=tractogram_filename, ext=['.tck'])]
     files.append(File(name='sph_func_filename', type_='input', path=sph_func_filename, ext=['.nii', '.nii.gz']))
     if out_weights_filename is not None:
-        files.append(File(name='out_weights_filename', type_='output', path=out_weights_filename, ext=['.txt', '.npy']))
+        if stat == 'all':
+            files.append(File(name='out_weights_filename', type_='output', path=out_weights_filename, ext=['.tsf']))
+        else:
+            files.append(File(name='out_weights_filename', type_='output', path=out_weights_filename, ext=['.txt', '.npy']))
     check_params(files=files, force=force)
 
     if trim<0 or trim>=0.5:
         logger.error('"trim" must be in [0..0.5)')
-    if stat not in ['min','mean','max']:
-        logger.error('"stat" must be one of [min, mean, max])')
+    if stat not in ['min','mean','max','all']:
+        logger.error('"stat" must be one of [min, mean, max, all]')
 
     #----- iterate over input streamlines -----
     TCK_in = None
@@ -2361,6 +2366,8 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
         # open tractogram
         TCK_in = LazyTractogram( tractogram_filename, mode='r' )
         n_streamlines = int( TCK_in.header['count'] )
+        if stat == 'all':
+            TSF_out = TrackScalarFile( out_weights_filename, mode='w', header=TCK_in.header )
         logger.subinfo(f'Number of streamlines: {n_streamlines}', indent_char='*', indent_lvl=1)
         if n_streamlines <= 0:
             logger.error('The tractogram is empty')
@@ -2393,7 +2400,7 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
 
         logger.subinfo(f'Summary statistic: {stat}', indent_char='*', indent_lvl=1)
         logger.subinfo(f'Normalization: {normalize}', indent_char='*', indent_lvl=1)
-        logger.subinfo(f'Trimmed {trim*100:.1f}% of points at each extremity', indent_char='*', indent_lvl=1)
+        logger.subinfo(f'Trimmed {trim*100:.1f}% of segments at each extremity', indent_char='*', indent_lvl=1)
         logger.subinfo(f'Coordinates shifted by {shift:.1f} voxel', indent_char='*', indent_lvl=1)
 
         # process every streamline
@@ -2405,7 +2412,7 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                     if TCK_in.n_pts==0:
                         break # no more data, stop reading
 
-                    trim_offset = int( floor(TCK_in.n_pts*trim) ) # skip 'trim' percent of points
+                    trim_offset = int( floor((TCK_in.n_pts-1)*trim) ) # skip 'trim' percent of segments
                     if TCK_in.n_pts - trim_offset*2 <=0 :
                         logger.warning( f'"trim" too high, streamline {i} is empty; coherence set to 0' )
                         coherence[i] = 0
@@ -2414,7 +2421,7 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                     P = TCK_in.streamline[trim_offset]
                     apply_affine_1pt(P, affine_inv, p1, shift)
                     n = 0
-                    for j in range(trim_offset+1,TCK_in.n_pts-trim_offset):
+                    for j in range(trim_offset+1,TCK_in.n_pts-trim_offset+1):
                         P = TCK_in.streamline[j]
                         apply_affine_1pt(P, affine_inv, p2, shift)
                         vx = int( floor(0.5*(p2[0]+p1[0])) )
@@ -2463,11 +2470,28 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                         coherence[i] = np.nanmean( w[:n] )
                     elif stat=='max':
                         coherence[i] = np.nanmax( w[:n] )
+                    elif stat=='all':
+                        coherence_tsf = np.full(TCK_in.n_pts, -1, dtype=np.float32)
+                        for x in range(n):
+                            if x == 0:
+                                coherence_tsf[x+trim_offset] = w[x]
+                            elif x == n-1:
+                                coherence_tsf[x+trim_offset] = w[x]
+                            else:
+                                coherence_tsf[x+trim_offset] = (w[x-1]+w[x])/2
+                        # print([i for i in coherence_tsf])
+                        # print(f' \n \n ')
+                        TSF_out.write_scalars( coherence_tsf, TCK_in.n_pts )
+
                     pbar.update()
-            logger.subinfo(f'Estimated weights:  min={np.min(coherence):.3f}  max={np.max(coherence):.3f}  mean={np.mean(coherence):.3f}  std={np.std(coherence):.3f}', indent_char='*', indent_lvl=1)
+            if stat != 'all':
+                logger.subinfo(f'Estimated weights:  min={np.min(coherence):.3f}  max={np.max(coherence):.3f}  mean={np.mean(coherence):.3f}  std={np.std(coherence):.3f}', indent_char='*', indent_lvl=1)
 
         if out_weights_filename is not None:
-            if out_weights_filename.endswith('.txt'):
+            if stat == 'all':
+                if TSF_out is not None:
+                    TSF_out.close()
+            elif out_weights_filename.endswith('.txt'):
                 np.savetxt(out_weights_filename, coherence, fmt='%.4f')
             else:
                 np.save(out_weights_filename, coherence, allow_pickle=False)

--- a/dicelib/tractogram.pyx
+++ b/dicelib/tractogram.pyx
@@ -2329,14 +2329,14 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
     array of float
         The estimate coherence weights for all input streamlines.
     """
-    cdef float [::1] w = np.full(10000, -1, dtype=np.float32) #NOTE: assume max length of a streamline = 10000
+    cdef float [::1] w = np.zeros(10000, dtype=np.float32) #NOTE: assume max length of a streamline = 10000
     cdef float [:] p1 = np.zeros(3, dtype=np.float32)
     cdef float [:] p2 = np.zeros(3, dtype=np.float32)
     cdef float [:] dir = np.zeros(3, dtype=np.float32)
     cdef float [:,:,:,::1] niiSF_img
     cdef float [:,::1] SHbasis
     cdef short [:] htable
-    cdef float [:] sf_voxel = np.zeros(500, dtype=np.float32)
+    cdef float [::1] sf_voxel = np.zeros(500, dtype=np.float32)
     cdef float [:] coherence, coherence_tsf
     cdef double [:,::1] affine_inv
     cdef LazyTractogram TCK_in = None
@@ -2348,7 +2348,7 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
 
     t0 = time()
     set_verbose('tractogram', verbose)
-    logger.info('Computing coherence of streamlines')
+    logger.info('Computing coherence')
 
     files = [File(name='tractogram_filename', type_='input', path=tractogram_filename, ext=['.tck'])]
     files.append(File(name='sph_func_filename', type_='input', path=sph_func_filename, ext=['.nii', '.nii.gz']))
@@ -2395,16 +2395,16 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
         theta = np.zeros( dirs.shape[0] )
         phi = np.zeros( dirs.shape[0] )
         for i in range(theta.size):
-            phi[i] = atan2( dirs[i,1], dirs[i,0] )#/M_PI*180.0
+            phi[i] = atan2(dirs[i,1], dirs[i,0])#/M_PI*180.0
             theta[i] = atan2( sqrt(dirs[i,0]*dirs[i,0]+dirs[i,1]*dirs[i,1]), dirs[i,2] )#/M_PI*180.0
-        tmp, _, _ = real_sh_tournier( lmax, theta, phi )
-        SHbasis = np.asarray(tmp,dtype=np.float32)
+        tmp, _, _ = real_sh_tournier(lmax, theta, phi)
+        SHbasis = np.asarray(tmp, dtype=np.float32)
         del dirs, theta, phi, tmp
 
-        logger.subinfo(f'Summary statistic: {stat}', indent_char='*', indent_lvl=1)
-        logger.subinfo(f'Normalization: {normalize}', indent_char='*', indent_lvl=1)
-        logger.subinfo(f'Trimmed {trim*100:.1f}% of segments at each extremity', indent_char='*', indent_lvl=1)
         logger.subinfo(f'Coordinates shifted by {shift:.1f} voxel', indent_char='*', indent_lvl=1)
+        logger.subinfo(f'Trimmed {trim*100:.1f}% of segments at each extremity', indent_char='*', indent_lvl=1)
+        logger.subinfo(f'Normalization: {normalize}', indent_char='*', indent_lvl=1)
+        logger.subinfo(f'Summary statistic along streamlines: "{stat}"', indent_char='*', indent_lvl=1)
 
         # process every streamline
         coherence = np.zeros( n_streamlines, dtype=np.float32 )
@@ -2448,7 +2448,7 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                         vy = int( floor(0.5*(p2[1]+p1[1])) )
                         vz = int( floor(0.5*(p2[2]+p1[2])) )
                         if normalize == False:
-                            # computes SHbasis[o,:] @ niiSF_img[vx,vy,vz,:]
+                            # compute SHbasis[o,:] @ niiSF_img[vx,vy,vz,:]
                             ptr1 = &SHbasis[o,0]
                             ptr2 = &niiSF_img[vx,vy,vz,0]
                             val = 0
@@ -2456,16 +2456,16 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                                 val += ptr1[k]*ptr2[k]
                             w[n] = val
                         else:
+                            # normalize by the max value in the voxel
                             sf_voxel = np.dot(SHbasis, niiSF_img[vx,vy,vz,:])
-                            m = np.max( sf_voxel )
-                            if m > 0:
-                                w[n] = sf_voxel[o] / m # normalization by the max value in the voxel
+                            val = np.max( sf_voxel )
+                            if val > 0:
+                                w[n] = sf_voxel[o] / val
                             else:
                                 w[n] = 0
                         # crop to zero negative values
                         if w[n] < 0:
                             w[n] = 0
-
                         p1[0] = p2[0]
                         p1[1] = p2[1]
                         p1[2] = p2[2]
@@ -2489,8 +2489,9 @@ cpdef compute_coherence( tractogram_filename: str, sph_func_filename: str, out_w
                         TSF_out.write_scalars( coherence_tsf, TCK_in.n_pts )
 
                     pbar.update()
+
             if stat != 'all':
-                logger.subinfo(f'Estimated weights:  min={np.min(coherence):.3f}  max={np.max(coherence):.3f}  mean={np.mean(coherence):.3f}  std={np.std(coherence):.3f}', indent_char='*', indent_lvl=1)
+                logger.subinfo(f'Estimated coherence:  {np.mean(coherence):.3f} ± {np.std(coherence):.3f} [min={np.min(coherence):.3f}, max={np.max(coherence):.3f}]', indent_char='*', indent_lvl=1)
 
         if out_weights_filename is not None:
             if stat == 'all':

--- a/dicelib/utils.py
+++ b/dicelib/utils.py
@@ -54,7 +54,8 @@ def check_params(files: Optional[List[File]]=None, dirs: Optional[List[Dir]]=Non
                     file.ext = [file.ext]
                 suffixes = pathlib.Path(file.path).suffixes
                 if len(suffixes) == 0:
-                    logger.error(f'File \'{file.path}\' has no extension; must be in {{{', '.join(file.ext)}}}')
+                    exts = ', '.join(file.ext)
+                    logger.error(f'File \'{file.path}\' has no extension; must be in {{{exts}}}')
                 elif len(suffixes) > 1:
                     if suffixes[-1] == '.gz':
                         suffixes = suffixes[-2:]
@@ -62,7 +63,8 @@ def check_params(files: Optional[List[File]]=None, dirs: Optional[List[Dir]]=Non
                         suffixes = suffixes[-1]
                 suffix = ''.join(suffixes)
                 if suffix not in file.ext or suffix == '':
-                    logger.error(f'File \'{file.path}\' has an invalid extension; must be in {{{', '.join(file.ext)}}}')
+                    exts = ', '.join(file.ext)
+                    logger.error(f'File \'{file.path}\' has an invalid extension; must be in {{{exts}}}')
             if file.type_ == 'input':
                 if not os.path.isfile(file.path):
                     logger.error(f'File \'{file.path}\' not found')


### PR DESCRIPTION
Added support for the 'all' value in the '--stat' parameter of compute_coherence(). When selected, coherence is computed for each segment along the streamlines and saved to a .tsf file.